### PR TITLE
Talk to Google Analytics over HTTPS no matter what

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,10 @@
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
         ga('create', 'UA-55807298-1', 'auto');
+        ga('set', 'forceSSL', true);
         ga('send', 'pageview');
     </script>
 </body>


### PR DESCRIPTION
This sets Google's `forceSSL` flag, which tells the snippet to use HTTPS to talk to Google during reporting. I also de-protocol-relative-d the initial call to `analytics.js`. 

Your site could still be downgraded/MITMed/etc, but `ninjadoge24.github.io` seems like a lot unlikelier of a target on a hostile network than `www.google-analytics.com`.