### PR TITLE
Enforce HTTPS on production domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script>
+        var host = "ninjadoge24.github.io";
+        if ((host == window.location.host) && (window.location.protocol != "https:"))
+            window.location.protocol = "https";
+    </script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="google-site-verification" content="-YcMCt3q4z8rSKghGahhaHxy8W-gHY5339-YUMfSlHA" />


### PR DESCRIPTION
Takes advantage of [GitHub Pages' tepid but present support for HTTPS](https://konklone.com/post/github-pages-now-sorta-supports-https-so-use-it) to do a client-side redirect to HTTPS when it's running on its production `github.io` domain. Yeah, it's client-side, but it substantially raises the likelihood that people will create links and bookmarks to your site that use `https://`.